### PR TITLE
Add missing "TARGET_LD=$TARGET_BIN/ld" to i386-apple-darwin11-ld.

### DIFF
--- a/i386-apple-darwin11-ld
+++ b/i386-apple-darwin11-ld
@@ -3,5 +3,6 @@
 TARGET_PLATFORM=`xcrun --show-sdk-platform-path --sdk iphonesimulator`
 TARGET_BIN=`xcrun --show-sdk-platform-path --sdk iphonesimulator`/Developer/usr/bin
 TARGET_LDFLAGS="-L$TARGET_PLATFORM/usr/lib/ -arch i386"
+TARGET_LD=$TARGET_BIN/ld
 
 exec $TARGET_LD $TARGET_LDFLAGS "$@"


### PR DESCRIPTION
It looks like something like "TARGET_LD=$TARGET_BIN/ld" is missing in i386-apple-darwin11-ld.