### PR TITLE
Define $TARGET_LD variable in the i386 ld script to avoid exec errors

### DIFF
--- a/i386-apple-darwin11-ld
+++ b/i386-apple-darwin11-ld
@@ -2,6 +2,8 @@
 
 TARGET_PLATFORM=`xcrun --show-sdk-platform-path --sdk iphonesimulator`
 TARGET_BIN=`xcrun --show-sdk-platform-path --sdk iphonesimulator`/Developer/usr/bin
+
+TARGET_LD=$TARGET_BIN/ld
 TARGET_LDFLAGS="-L$TARGET_PLATFORM/usr/lib/ -arch i386"
 
 exec $TARGET_LD $TARGET_LDFLAGS "$@"


### PR DESCRIPTION
When I run `cabal-ios install [foo]`, I get the same error on every sub-dependency of [foo] that cabal tries to compile:

```
Downloading random-1.1...
Configuring random-1.1...
Building random-1.1...
Preprocessing library random-1.1...
[1 of 1] Compiling System.Random    ( System/Random.hs, dist/i386/build/System/Random.o )
/Users/[me]/src/ghc-ios-scripts/i386-apple-darwin11-ld: line 7: exec: -L: invalid option
exec: usage: exec [-cl] [-a name] file [redirection ...]
Failed to install random-1.1
```

This seems to be because $TARGET_LD is not defined anywhere in the i386-apple-darwin11-ld script. But it *is* defined in the aarch64 equivalent script. If we copypasta the TARGET_LD definition from the aarch64 script to the i386 one, this exec error goes away, and cabal-ios can get further towards successfully cross-compiling a given package for the iOS simulator.

Note: I am not super familiar with ghc or cross-compilation, so there may be better solutions than what I've done. I'm largely playing whack-a-mole here as I run through the process of trying to cross-compile an existing Haskell library for iOS.