### PR TITLE
add LC_ALL=C before the sed calls in installGHCiOS.sh; fixes #17

### DIFF
--- a/installGHCiOS.sh
+++ b/installGHCiOS.sh
@@ -21,6 +21,7 @@ cd ghc-7.8.3-arm
 # Remove befuddling inclusion of my local paths
 LC_CTYPE=C 
 LANG=C
+LC_ALL=C
 find . -type f -not -name .DS_Store -not -name "*.a" -print0 | xargs -0 sed -i '' 's|/Users/lukexi/Code/ghc-ios-scripts/||g'
 
 ./configure
@@ -43,6 +44,7 @@ cd ghc-7.8.3-i386
 # ditto above
 LC_CTYPE=C 
 LANG=C
+LC_ALL=C
 find . -type f -not -name .DS_Store -not -name "*.a" -print0 | xargs -0 sed -i '' 's|/Users/lukexi/Code/ghc-ios-scripts/||g'
 
 ./configure


### PR DESCRIPTION
Solution taken from http://stackoverflow.com/questions/19242275/re-error-illegal-byte-sequence-on-mac-os-x
